### PR TITLE
[REVIEW] Updated the thrust::sort in the CSV reader to use device

### DIFF
--- a/src/io/csv/csv-reader.cu
+++ b/src/io/csv/csv-reader.cu
@@ -220,7 +220,7 @@ gdf_error read_csv(csv_read_arg *args)
 
 	cudaDeviceSynchronize();
 
-	thrust::sort(raw_csv->recStart, raw_csv->recStart + raw_csv->num_records + 1);
+	thrust::sort(thrust::device, raw_csv->recStart, (raw_csv->recStart + raw_csv->num_records + 1));
 
 	raw_csv->num_records -= (args->skiprows + args->skipfooter); 
 
@@ -631,6 +631,7 @@ gdf_error launch_dataConvertColumns(raw_csv_t * raw_csv, void **gdf, gdf_valid_t
 		row_offset,
 		raw_csv->dayfirst
 	);
+
 
 
 	return GDF_SUCCESS;


### PR DESCRIPTION
… on device.

<!--

Thanks for wanting to contribute to libGDF :)

First, if you need some help or want to chat to the core developers, please
visit http://gpuopenanalytics.com/#/COMMUNITY for links to Slack and Google
Groups.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label and replace it with `[REVIEW]` when you'd like it to
   be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->

The `thrust::sort` in the CSV reader did not specify to use the device, which could lead to sorting on the Host and causing poor performance.
