### PR TITLE
[REVIEW] CMake: Fix Arrow and GTest library paths

### DIFF
--- a/cmake/Modules/ConfigureGoogleTest.cmake
+++ b/cmake/Modules/ConfigureGoogleTest.cmake
@@ -52,3 +52,5 @@ set(GTEST_ROOT ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdparty/googletest
 message(STATUS "GTEST_ROOT: " ${GTEST_ROOT})
 
 link_directories(${GTEST_ROOT}/lib/)
+link_directories(${GTEST_ROOT}/lib/x86_64-linux-gnu)
+link_directories(${GTEST_ROOT}/lib64)

--- a/cmake/Modules/ConfigureGoogleTest.cmake
+++ b/cmake/Modules/ConfigureGoogleTest.cmake
@@ -52,5 +52,5 @@ set(GTEST_ROOT ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/thirdparty/googletest
 message(STATUS "GTEST_ROOT: " ${GTEST_ROOT})
 
 link_directories(${GTEST_ROOT}/lib/)
-link_directories(${GTEST_ROOT}/lib/x86_64-linux-gnu)
-link_directories(${GTEST_ROOT}/lib64)
+link_directories(${GTEST_ROOT}/lib/x86_64-linux-gnu/)
+link_directories(${GTEST_ROOT}/lib64/)

--- a/cmake/Modules/FindArrow.cmake
+++ b/cmake/Modules/FindArrow.cmake
@@ -72,7 +72,7 @@ else()
 
     # Determine arrow version information for CPP macros
     get_filename_component(ARROW_STATIC_LIB_DIR ${ARROW_STATIC_LIB} DIRECTORY)
-    file(STRINGS ${ARROW_LIB_DIR}/pkgconfig/arrow.pc _ARROW_VERSION REGEX "^Version: ([0-9]+\\.[0-9]+\\.[0-9]+)")
+    file(STRINGS ${ARROW_STATIC_LIB_DIR}/pkgconfig/arrow.pc _ARROW_VERSION REGEX "^Version: ([0-9]+\\.[0-9]+\\.[0-9]+)")
     STRING(REGEX REPLACE "^Version: ([0-9]+)\\.[0-9]+\\.[0-9]+" "\\1" ARROW_VERSION_MAJOR "${_ARROW_VERSION}")
     STRING(REGEX REPLACE "^Version: [0-9]+\\.([0-9]+)\\.[0-9]+" "\\1" ARROW_VERSION_MINOR "${_ARROW_VERSION}")
     STRING(REGEX REPLACE "^Version: [0-9]+\\.[0-9]+\\.([0-9]+)" "\\1" ARROW_VERSION_PATCH "${_ARROW_VERSION}")

--- a/cmake/Modules/FindArrow.cmake
+++ b/cmake/Modules/FindArrow.cmake
@@ -71,7 +71,8 @@ else()
     set_target_properties(arrow PROPERTIES IMPORTED_LOCATION "${ARROW_STATIC_LIB}")
 
     # Determine arrow version information for CPP macros
-    file(STRINGS ${ARROW_ROOT}/lib/pkgconfig/arrow.pc _ARROW_VERSION REGEX "^Version: ([0-9]+\\.[0-9]+\\.[0-9]+)")
+    get_filename_component(ARROW_STATIC_LIB_DIR ${ARROW_STATIC_LIB} DIRECTORY)
+    file(STRINGS ${ARROW_LIB_DIR}/pkgconfig/arrow.pc _ARROW_VERSION REGEX "^Version: ([0-9]+\\.[0-9]+\\.[0-9]+)")
     STRING(REGEX REPLACE "^Version: ([0-9]+)\\.[0-9]+\\.[0-9]+" "\\1" ARROW_VERSION_MAJOR "${_ARROW_VERSION}")
     STRING(REGEX REPLACE "^Version: [0-9]+\\.([0-9]+)\\.[0-9]+" "\\1" ARROW_VERSION_MINOR "${_ARROW_VERSION}")
     STRING(REGEX REPLACE "^Version: [0-9]+\\.[0-9]+\\.([0-9]+)" "\\1" ARROW_VERSION_PATCH "${_ARROW_VERSION}")


### PR DESCRIPTION
When looking for `arrow.pc`, it is assumed that `${ARROW_ROOT}/lib` is the path containing the arrow library. This PR ensures that `arrow.pc` is found even if the library is in a location such as `${ARROW_ROOT}/lib64` or `${ARROW_ROOT}/lib/x86_64-linux-gnu`.

Similarly, the directories for finding GTest libraries is expanded to include `{GTEST_ROOT}/lib/x86_64-linux-gnu` and `${GTEST_ROOT}/lib64`.