### PR TITLE
[WIP] Upgrade the gcc compiler for Travis CI (version 5).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,31 +16,36 @@ env:
 
 matrix:
   include:
-    - env: CUDA=9.0.176_384.81
-    - env: CUDA=9.1.85_387.26
-    - env: CUDA=9.2.148_396.37
+#    - env: CUDA=9.0.176_384.81
+#    - env: CUDA=9.1.85_387.26
+#    - env: CUDA=9.2.148_396.37
     - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.6
-    - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.5
-    - os: linux
-      addons:
-        apt:
-          update:
-            - true
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-        - COMPILER_EVAL="CC=gcc-5 && CXX=g++-5"
+#    - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.5
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-5
+    update:
+      - true
 
 before_install:
-  - eval "${COMPILER_EVAL}"
+  # update links for gcc-5
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 1 --slave /usr/bin/gcc gcc /usr/bin/gcc-5
+  - eval "${CC} --version"
+  - eval "${CXX} --version"
+
+  # Install CUDA toolkit
   - source ./travisci/install-cuda-trusty.sh
+
   # install miniconda
   - travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=$HOME/miniconda3/bin:$PATH
+
   # install libboost
   - sudo apt-get install -y libboost-all-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,8 @@ before_install:
   # update links for gcc-5
   # install gcc-5
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq g++-5
+  - sudo apt-get update
+  - sudo apt-get install -y g++-5
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 1 --slave /usr/bin/gcc gcc /usr/bin/gcc-5
   - eval "${CC} --version"
   - eval "${CXX} --version"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,21 @@ matrix:
     - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.6
 #    - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.5
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-5
-    update:
-      - true
+#addons:
+#  apt:
+#    sources:
+#      - ubuntu-toolchain-r-test
+#    packages:
+#      - g++-5
+#    update:
+#      - true
 
 before_install:
   # update links for gcc-5
+  # install gcc-5
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq g++-5
   - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 1 --slave /usr/bin/gcc gcc /usr/bin/gcc-5
   - eval "${CC} --version"
   - eval "${CXX} --version"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,20 @@ matrix:
     - env: CUDA=9.2.148_396.37
     - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.6
     - env: CUDA=9.0.176_384.81 BUILD_CFFI=1 PYTHON=3.5
-
+    - os: linux
+      addons:
+        apt:
+          update:
+            - true
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - COMPILER_EVAL="CC=gcc-5 && CXX=g++-5"
 
 before_install:
+  - eval "${COMPILER_EVAL}"
   - source ./travisci/install-cuda-trusty.sh
   # install miniconda
   - travis_retry wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
@@ -31,7 +42,6 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=$HOME/miniconda3/bin:$PATH
   # install libboost
-  - sudo apt-get update
   - sudo apt-get install -y libboost-all-dev
 
 install:


### PR DESCRIPTION
There are some issues related to the 'libgdf' library compiled in the TravisCI hosted service, due to it presents some errors when the library is tested against the 'pygdf' library tests.

A possible solution is to upgrade the 'gcc' compiler to the 5 version. Currently, it is used the 4.8.4 version, which is the default version for the 'trusty' build environment.