### PR TITLE
[REVIEW] Add support for windows files that are terminated with \r\n

### DIFF
--- a/src/io/csv/csv-reader.cu
+++ b/src/io/csv/csv-reader.cu
@@ -707,7 +707,7 @@ __global__ void convertCsvToGdf(
 			if(raw_csv[pos]==delim){
 				break;
 			}
-            else if(raw_csv[pos] == '\r' ||  (pos < stop && raw_csv[pos+1]=='\n')){
+            else if(raw_csv[pos] == '\r' &&  (pos < stop && raw_csv[pos+1]=='\n')){
             	stop--;
                 break;
             }

--- a/src/io/csv/csv-reader.cu
+++ b/src/io/csv/csv-reader.cu
@@ -707,8 +707,13 @@ __global__ void convertCsvToGdf(
 			if(raw_csv[pos]==delim){
 				break;
 			}
+            else if(raw_csv[pos] == '\r' ||  (pos < stop && raw_csv[pos+1]=='\n')){
+            	stop--;
+                break;
+            }
 			if(pos>=stop)
 				break;
+
 			pos++;
 		}
 


### PR DESCRIPTION
Currently, the csv reader is not able to detect either the `\r` or the `\n` for Windows termination of rows. 
The following PR corrects this.