### PR TITLE
[WIP] simplify travis-ci + conda build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,10 @@ include(CTest)
 include(ConfigureGoogleTest)
 include(ConfigureArrow)
 
+if( DEFINED ENV{CONDA_PREFIX} )
+  set( CMAKE_SYSTEM_PREFIX_PATH $ENV{CONDA_PREFIX}/$ENV{HOST}/sysroot;${CMAKE_SYSTEM_PREFIX_PATH} )
+endif()
+
 find_package(CUDA)
 set_package_properties(
     CUDA PROPERTIES TYPE REQUIRED
@@ -71,6 +75,9 @@ else()
 endif()
 
 # Locate the Apache Arrow package (Requires that you use ConfigureArrow module)
+if( DEFINED ENV{CONDA_PREFIX} )
+  set( ARROW_ROOT $ENV{CONDA_PREFIX} )
+endif()
 message(STATUS "ARROW_ROOT: " ${ARROW_ROOT})
 find_package(Arrow REQUIRED)
 set_package_properties(Arrow PROPERTIES TYPE REQUIRED

--- a/cmake/Modules/ConfigureArrow.cmake
+++ b/cmake/Modules/ConfigureArrow.cmake
@@ -31,7 +31,7 @@ if(result)
 endif()
 
 execute_process(
-    COMMAND ${CMAKE_COMMAND} --build .
+    COMMAND ${CMAKE_COMMAND} -DCMAKE_SYSTEM_PREFIX_PATH=${CMAKE_SYSTEM_PREFIX_PATH} --build .
     RESULT_VARIABLE result
     WORKING_DIRECTORY ${ARROW_DOWNLOAD_BINARY_DIR}
 )
@@ -59,10 +59,27 @@ else()
   set(ARROW_GENERATED_IPC_DIR ${ARROW_DOWNLOAD_BINARY_DIR}/arrow-prefix/src/arrow-build/src/arrow/ipc/)
 endif()
 
-configure_file(${ARROW_GENERATED_IPC_DIR}/File_generated.h ${CMAKE_SOURCE_DIR}/include/gdf/ipc/File_generated.h COPYONLY)
-configure_file(${ARROW_GENERATED_IPC_DIR}/Message_generated.h ${CMAKE_SOURCE_DIR}/include/gdf/ipc/Message_generated.h COPYONLY)
-configure_file(${ARROW_GENERATED_IPC_DIR}/Schema_generated.h ${CMAKE_SOURCE_DIR}/include/gdf/ipc/Schema_generated.h COPYONLY)
-configure_file(${ARROW_GENERATED_IPC_DIR}/Tensor_generated.h ${CMAKE_SOURCE_DIR}/include/gdf/ipc/Tensor_generated.h COPYONLY)
+find_file( File_generated_header
+  File_generated.h
+  PATHS ${ARROW_GENERATED_IPC_DIR};${CMAKE_CURRENT_SOURCE_DIR}/include/gdf/ipc
+)
+find_file( Message_generated_header
+  Message_generated.h
+  PATHS ${ARROW_GENERATED_IPC_DIR};${CMAKE_CURRENT_SOURCE_DIR}/include/gdf/ipc
+)
+find_file( Schema_generated_header
+  Schema_generated.h
+  PATHS ${ARROW_GENERATED_IPC_DIR};${CMAKE_CURRENT_SOURCE_DIR}/include/gdf/ipc
+)
+find_file( Tensor_generated_header
+  Tensor_generated.h
+  PATHS ${ARROW_GENERATED_IPC_DIR};${CMAKE_CURRENT_SOURCE_DIR}/include/gdf/ipc
+)
+
+configure_file(${File_generated_header} ${CMAKE_SOURCE_DIR}/include/gdf/ipc/File_generated.h COPYONLY)
+configure_file(${Message_generated_header} ${CMAKE_SOURCE_DIR}/include/gdf/ipc/Message_generated.h COPYONLY)
+configure_file(${Schema_generated_header} ${CMAKE_SOURCE_DIR}/include/gdf/ipc/Schema_generated.h COPYONLY)
+configure_file(${Tensor_generated_header} ${CMAKE_SOURCE_DIR}/include/gdf/ipc/Tensor_generated.h COPYONLY)
 
 # Add transitive dependency: Flatbuffers
 set(FLATBUFFERS_ROOT ${ARROW_DOWNLOAD_BINARY_DIR}/arrow-prefix/src/arrow-build/flatbuffers_ep-prefix/src/flatbuffers_ep-install/)

--- a/conda_environments/dev_py35.yml
+++ b/conda_environments/dev_py35.yml
@@ -19,9 +19,15 @@ dependencies:
 - sqlite=3.13.0=0
 - tk=8.5.18=0
 - wheel=0.29.0=py35_0
-- xz=5.2.2=1
+- xz>=5.2.4,<5.3.0
 - zlib>=1.2.8,<1.3
 - llvmlite=0.18.0=py35_0
 - numba=0.34.0.dev=np112py35_316
-- cmake=3.6.3=0
+- cmake=3.12.0
 - pyarrow=0.10.0
+- gcc_linux-64=7.2.0
+- gxx_linux-64=7.2.0
+- conda-build
+- anaconda-client
+- libboost=1.65.1
+- conda-verify

--- a/travisci/Dockerfile
+++ b/travisci/Dockerfile
@@ -1,0 +1,59 @@
+ARG CUDA_VERSION=9.2
+ARG UBUNTU_VERSION=16.04
+
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
+
+ARG CONDA_USER=conda
+ARG GTEST_VERSION=1.8.1
+
+# Set environment
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda/lib64:/usr/local/lib
+
+## Locked to Pandas 0.20.3 by https://github.com/gpuopenanalytics/pygdf/issues/118
+ENV PANDAS_VERSION=0.20.3
+
+#The basics - TODO: get rid of git in the image
+RUN apt update -y --fix-missing && \
+    apt upgrade -y && \
+    apt install -y \
+      git vim curl \
+      libboost-all-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/conda/bin:$PATH"
+SHELL ["/bin/bash", "-c"]
+
+ADD https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh miniconda.sh 
+ADD conda_environments/dev_py35.yml dev_py35.yml
+RUN sh ./miniconda.sh -b -p /conda && \
+    conda update -n base conda && \
+    conda config --set report_errors false && \
+    conda env create -n libgdf -f dev_py35.yml
+
+# gtest depenencies stage
+#ADD https://github.com/google/googletest/archive/release-${GTEST_VERSION}.tar.gz /tmp/googletest.tar.gz
+#RUN mkdir -p googletest/build && \
+#    tar -C googletest -xzf /tmp/googletest.tar.gz && \
+#    cd googletest/build && \
+#    /bin/bash -c "source /conda/etc/profile.d/conda.sh && \
+#                  conda activate libgdf ; \
+#                  cmake -DCMAKE_PREFIX_PATH=/conda/envs/libgdf/x86_64-conda_cos6-linux-gnu/sysroot \
+#                        ../googletest-release-${GTEST_VERSION} ; \
+#                  export DESTDIR=/conda/envs/libgdf/x86_64-conda_cos6-linux-gnu/sysroot && \
+#                  make && make install" && \
+#    cd .. && rm -rf googletest && rm /tmp/googletest.tar.gz
+
+
+# Change to a non-root user so that it executes with minimum privilege
+RUN groupadd --gid 3000 conda && \
+    useradd -g conda -ms /bin/bash ${CONDA_USER} && \
+    cat /conda/etc/profile.d/conda.sh >> /home/${CONDA_USER}/.bashrc && \
+    chgrp -R conda /conda && \
+    chmod -R g+rwx /conda
+WORKDIR /home/${CONDA_USER}
+USER ${CONDA_USER}
+
+
+#RUN or ENTRYPOINT ?
+
+


### PR DESCRIPTION
This is driven by the need to build libgdf with GCC 7.2 compiler packages and enable binary compatibility with other conda packages.

* isolate llibgdf build dependencies other than nvidia-cuda-toolkit so that they are expressed entirely in the conda environment yml
* make CMake scripts Conda aware so that paths are correctly updated when cmake is executed inside of a conda shell
* execute conda build scripts from travis-ci build and update libgdf conda package

TBD: run gtests
TBD: travisci.yml
TBD: conda_recipe
