### PR TITLE
[REVIEW] Make gdf_is_valid inline rather than static (Fix #176)

### DIFF
--- a/include/gdf/utils.h
+++ b/include/gdf/utils.h
@@ -4,7 +4,7 @@
 #include <gdf/gdf.h>
 
 __host__ __device__
-static
+inline
 bool gdf_is_valid(const gdf_valid_type *valid, gdf_index_type pos) {
 	if ( valid )
 		return (valid[pos / GDF_VALID_BITSIZE] >> (pos % GDF_VALID_BITSIZE)) & 1;


### PR DESCRIPTION
The build (of blazingdb/master) is currently broken because of bug #176 . So PR'ing a quick fix for it.

@felipeblazing : FYI.

By the way - I have to say I'm not particularly fond of the name of this function, nor is it clear to me whether or not it should be "exposed" like this under `include/gdf` - but I'm not getting into that with the fix, I'm just getting the repository to build.