### PR TITLE
Fix dataframe composition in full joins

### DIFF
--- a/src/join/joining.cu
+++ b/src/join/joining.cu
@@ -466,6 +466,7 @@ gdf_error construct_join_output_df(
         gdf_table<size_type> j_i_table(ljoincol.size(), ljoincol.data());
         gdf_table<size_type> j_table(num_cols_to_join, result_cols + left_table_end);
         //Gather valid rows from the right table
+	// TODO: Revisit this, because it probably can be done more efficiently
         if (JoinType::FULL_JOIN == join_type) {
             gdf_table<size_type> j_i_r_table(rjoincol.size(), rjoincol.data());
             err = j_i_r_table.gather(static_cast<index_type*>(right_indices->data),

--- a/src/join/joining.cu
+++ b/src/join/joining.cu
@@ -465,11 +465,12 @@ gdf_error construct_join_output_df(
     if (0 != ljoincol.size()) {
         gdf_table<size_type> j_i_table(ljoincol.size(), ljoincol.data());
         gdf_table<size_type> j_table(num_cols_to_join, result_cols + left_table_end);
-        //Full Join left indices need to be fixed before calling gather
+        //Gather valid rows from the right table
         if (JoinType::FULL_JOIN == join_type) {
             gdf_table<size_type> j_i_r_table(rjoincol.size(), rjoincol.data());
             err = j_i_r_table.gather(static_cast<index_type*>(right_indices->data),
                     j_table, join_type != JoinType::INNER_JOIN);
+            if (err != GDF_SUCCESS) { return err; }
         }
         err = j_i_table.gather(static_cast<index_type*>(left_indices->data),
                 j_table, join_type != JoinType::INNER_JOIN);

--- a/src/join/joining.cu
+++ b/src/join/joining.cu
@@ -412,7 +412,7 @@ gdf_error construct_join_output_df(
     }
     //TODO : Invalid api
 
-    size_t join_size = left_indices->size;
+    size_type join_size = left_indices->size;
     int left_table_end = num_left_cols - num_cols_to_join;
     int right_table_begin = num_left_cols;
 
@@ -442,6 +442,8 @@ gdf_error construct_join_output_df(
     }
 
     gdf_error err{GDF_SUCCESS};
+
+    //Construct the left columns
     if (0 != lnonjoincol.size()) {
         gdf_table<size_type> l_i_table(lnonjoincol.size(), lnonjoincol.data());
         gdf_table<size_type> l_table(num_left_cols - num_cols_to_join, result_cols);
@@ -449,6 +451,8 @@ gdf_error construct_join_output_df(
                 l_table, join_type != JoinType::INNER_JOIN);
         if (err != GDF_SUCCESS) { return err; }
     }
+
+    //Construct the right columns
     if (0 != rnonjoincol.size()) {
         gdf_table<size_type> r_i_table(rnonjoincol.size(), rnonjoincol.data());
         gdf_table<size_type> r_table(num_right_cols - num_cols_to_join, result_cols + right_table_begin);
@@ -457,10 +461,19 @@ gdf_error construct_join_output_df(
         if (err != GDF_SUCCESS) { return err; }
     }
 
-    gdf_table<size_type> j_i_table(ljoincol.size(), ljoincol.data());
-    gdf_table<size_type> j_table(num_cols_to_join, result_cols + left_table_end);
-    err = j_i_table.gather(static_cast<index_type*>(left_indices->data),
-            j_table, join_type != JoinType::INNER_JOIN);
+    //Construct the joined columns
+    if (0 != ljoincol.size()) {
+        gdf_table<size_type> j_i_table(ljoincol.size(), ljoincol.data());
+        gdf_table<size_type> j_table(num_cols_to_join, result_cols + left_table_end);
+        //Full Join left indices need to be fixed before calling gather
+        if (JoinType::FULL_JOIN == join_type) {
+            gdf_table<size_type> j_i_r_table(rjoincol.size(), rjoincol.data());
+            err = j_i_r_table.gather(static_cast<index_type*>(right_indices->data),
+                    j_table, join_type != JoinType::INNER_JOIN);
+        }
+        err = j_i_table.gather(static_cast<index_type*>(left_indices->data),
+                j_table, join_type != JoinType::INNER_JOIN);
+    }
 
 	POP_RANGE();
     return err;


### PR DESCRIPTION
Prior to this fix, dataframe creation was done by calling gather on the left indices result of the join. This was a problem for full join because elements from the right set of columns would never be gathered into the final dataframe.

This fix calls gather on the right indices of the full join result.

<!--

Thanks for wanting to contribute to libGDF :)

First, if you need some help or want to chat to the core developers, please
visit http://gpuopenanalytics.com/#/COMMUNITY for links to Slack and Google
Groups.

Here's some guidelines to help the review process go smoothly.

0. Please write a description in this text box of the changes that are being
   made.

1. Please ensure that you have written units tests for the changes made/features
   added.

2. If you are closing an issue please use one of the automatic closing words as
   noted here: https://help.github.com/articles/closing-issues-using-keywords/

3. If your pull request is not ready for review but you want to make use of the
   continuous integration testing facilities please label it with `[WIP]` and
   then remove the label and replace it with `[REVIEW]` when you'd like it to
   be reviewed.

4. Once review has taken place please do not add features or make changes out of
   the scope of those requested by the reviewer (doing this just add delays as
   already reviewed code ends up having to be re-reviewed/it is hard to tell
   what is new etc!). Further, please do not rebase your branch on master/force
   push/rewrite history, doing any of these causes the context of any comments
   made by reviewers to be lost. If conflicts occur against master they should
   be resolved by merging master into the branch used for making the pull
   request.

Many thanks in advance for your cooperation!

-->
